### PR TITLE
Fix some bugs

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -204,6 +204,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 99fa1d3c858848540b5623ac94e8d45c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDash: 0
+  canDash: 1
 --- !u!114 &815608262193296658
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -358,6 +360,10 @@ PrefabInstance:
     - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
       propertyPath: m_LocalRotation.x
@@ -590,6 +596,10 @@ PrefabInstance:
       value: -0.21
       objectReference: {fileID: 0}
     - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -759,10 +769,6 @@ PrefabInstance:
       propertyPath: _triggerCollider
       value: 
       objectReference: {fileID: 7698973864632822059}
-    - target: {fileID: 5546937352112817263, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
-      propertyPath: m_Radius
-      value: 1.3
-      objectReference: {fileID: 0}
     - target: {fileID: 5546937352615866292, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
       propertyPath: m_Size.x
       value: 1.1266667
@@ -804,16 +810,8 @@ PrefabInstance:
       value: -0.21
       objectReference: {fileID: 0}
     - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 22.5
       objectReference: {fileID: 0}
     - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
       propertyPath: m_ConstrainProportionsScale
@@ -1032,6 +1030,10 @@ PrefabInstance:
     - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
       propertyPath: m_LocalRotation.x
@@ -1262,6 +1264,10 @@ PrefabInstance:
     - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5546937352615866293, guid: 1d741ea56d1b794479ce3811f304d636, type: 3}
       propertyPath: m_LocalRotation.x

--- a/Assets/Prefabs/Player/RacketObject.prefab
+++ b/Assets/Prefabs/Player/RacketObject.prefab
@@ -46,8 +46,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3a9564e5d438beb4b90bbac50b5535f1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  racketGraphics: {fileID: 5546937352615866294}
-  racketRadius: 1.2
+  _triggerCollider: {fileID: 0}
+  _arcAngle: 45
+  swung:
+    m_PersistentCalls:
+      m_Calls: []
+  isChangingProjectileSpriteColor: 1
 --- !u!58 &5546937352112817263
 CircleCollider2D:
   m_ObjectHideFlags: 0
@@ -63,7 +67,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.5
+  m_Radius: 1.7
 --- !u!1 &5546937352615866294
 GameObject:
   m_ObjectHideFlags: 0
@@ -88,7 +92,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5546937352615866294}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0.19509031, w: 0.98078537}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.10839281, y: 0.10839281, z: 0.10839281}
   m_ConstrainProportionsScale: 0

--- a/Assets/Prefabs/UI/SetupPanel.prefab
+++ b/Assets/Prefabs/UI/SetupPanel.prefab
@@ -960,13 +960,13 @@ MonoBehaviour:
   m_MinValue: 0
   m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: VolumeSlider, Assembly-CSharp
-        m_MethodName: SetVoice
+        m_TargetAssemblyTypeName: SFXManager, Assembly-CSharp
+        m_MethodName: SetVolumeToSlider
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1211,13 +1211,13 @@ MonoBehaviour:
   m_MinValue: 0
   m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 0.5
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: VolumeSlider, Assembly-CSharp
-        m_MethodName: SetVoice
+        m_TargetAssemblyTypeName: MusicManager, Assembly-CSharp
+        m_MethodName: SetVolumeToSlider
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -373,6 +373,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7957886340027968919, guid: 7e7d6efedae829648a2680e696810ffc, type: 3}
   m_PrefabInstance: {fileID: 17427693}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &73166508 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1951643425307906478, guid: a6417ac7398a3bc49b5f4675836e6d16, type: 3}
+  m_PrefabInstance: {fileID: 1890811894}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &195050666
 GameObject:
   m_ObjectHideFlags: 0
@@ -853,6 +864,17 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 6454175579470090325, guid: a6417ac7398a3bc49b5f4675836e6d16, type: 3}
   m_PrefabInstance: {fileID: 1890811894}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1457508696 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 631952937173276370, guid: 9fa75e5522b04a842aa3fda049c40c89, type: 3}
+  m_PrefabInstance: {fileID: 631952938441091254}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b378158401ebb9a4fb5285ddd486a101, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1561727541 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1829363004776218621, guid: f1fd9ec2b3a732a4ea4a2ad7c395a7fa, type: 3}
@@ -916,9 +938,13 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2264458278943792562, guid: 88c8bd25d2cb97f48ac79a386803d166, type: 3}
+      propertyPath: _slider
+      value: 
+      objectReference: {fileID: 73166508}
+    - target: {fileID: 2264458278943792562, guid: 88c8bd25d2cb97f48ac79a386803d166, type: 3}
       propertyPath: serializationData.Prefab
       value: 
-      objectReference: {fileID: 2264458278943792562, guid: 88c8bd25d2cb97f48ac79a386803d166, type: 3}
+      objectReference: {fileID: 0}
     - target: {fileID: 2264458278943792563, guid: 88c8bd25d2cb97f48ac79a386803d166, type: 3}
       propertyPath: m_Name
       value: SFXManager
@@ -1177,6 +1203,10 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1951643425307906478, guid: a6417ac7398a3bc49b5f4675836e6d16, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1571582863}
     - target: {fileID: 3739535343020614396, guid: a6417ac7398a3bc49b5f4675836e6d16, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
@@ -1325,6 +1355,10 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6570393246618979088, guid: a6417ac7398a3bc49b5f4675836e6d16, type: 3}
+      propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1457508696}
     - target: {fileID: 7474089220930292622, guid: a6417ac7398a3bc49b5f4675836e6d16, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
@@ -1424,6 +1458,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2031188799 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6570393246618979088, guid: a6417ac7398a3bc49b5f4675836e6d16, type: 3}
+  m_PrefabInstance: {fileID: 1890811894}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2054696927
 GameObject:
   m_ObjectHideFlags: 0
@@ -1569,9 +1614,13 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 631952937173276370, guid: 9fa75e5522b04a842aa3fda049c40c89, type: 3}
+      propertyPath: _slider
+      value: 
+      objectReference: {fileID: 2031188799}
+    - target: {fileID: 631952937173276370, guid: 9fa75e5522b04a842aa3fda049c40c89, type: 3}
       propertyPath: serializationData.Prefab
       value: 
-      objectReference: {fileID: 631952937173276370, guid: 9fa75e5522b04a842aa3fda049c40c89, type: 3}
+      objectReference: {fileID: 0}
     - target: {fileID: 631952937173276370, guid: 9fa75e5522b04a842aa3fda049c40c89, type: 3}
       propertyPath: serializationData.PrefabModifications.Array.size
       value: 6

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -1960,10 +1960,6 @@ PrefabInstance:
       propertyPath: m_Offset.x
       value: 0.04
       objectReference: {fileID: 0}
-    - target: {fileID: 7698973864632822059, guid: f0e115be8f8edc14287e0c3f68a18148, type: 3}
-      propertyPath: m_Radius
-      value: 1.3
-      objectReference: {fileID: 0}
     - target: {fileID: 7698973864632822060, guid: f0e115be8f8edc14287e0c3f68a18148, type: 3}
       propertyPath: m_LocalScale.x
       value: 1
@@ -2101,24 +2097,8 @@ PrefabInstance:
       value: -0.21
       objectReference: {fileID: 0}
     - target: {fileID: 7698973865135882993, guid: f0e115be8f8edc14287e0c3f68a18148, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7698973865135882993, guid: f0e115be8f8edc14287e0c3f68a18148, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7698973865135882993, guid: f0e115be8f8edc14287e0c3f68a18148, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7698973865135882993, guid: f0e115be8f8edc14287e0c3f68a18148, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7698973865135882993, guid: f0e115be8f8edc14287e0c3f68a18148, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
+      value: 22.5
       objectReference: {fileID: 0}
     - target: {fileID: 7698973865135882993, guid: f0e115be8f8edc14287e0c3f68a18148, type: 3}
       propertyPath: m_ConstrainProportionsScale

--- a/Assets/Scripts/Manager/MusicManager.cs
+++ b/Assets/Scripts/Manager/MusicManager.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Sirenix.OdinInspector;
 using UnityEngine.SceneManagement;
+using UnityEngine.UI;
 
 [RequireComponent(typeof(AudioSource))]
 public class MusicManager : Singleton<MusicManager>
@@ -17,6 +18,8 @@ public class MusicManager : Singleton<MusicManager>
 
     private float _volume = 0.5f; // TODO: Only for testing purpose
     private string _playName;
+
+    [SerializeField] Slider _slider;
 
     void Awake()
     {
@@ -38,6 +41,12 @@ public class MusicManager : Singleton<MusicManager>
         _volume = num;
         _audioSource1.volume = _volume;
         _audioSource2.volume = _volume;
+    }
+
+    public void SetVolumeToSlider()
+    {
+        if (_slider == null) { return; }
+        SetVolume(_slider.value);
     }
 
     public void Mute()

--- a/Assets/Scripts/Manager/SFXManager.cs
+++ b/Assets/Scripts/Manager/SFXManager.cs
@@ -4,6 +4,7 @@ using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.Events;
 using Sirenix.OdinInspector;
+using UnityEngine.UI;
 
 [RequireComponent(typeof(AudioSource))]
 public class SFXManager : Singleton<SFXManager>
@@ -11,6 +12,8 @@ public class SFXManager : Singleton<SFXManager>
     public Dictionary<string, AudioClip> sfxClips = new Dictionary<string, AudioClip>();
     private AudioSource _audioSource;
     private float _volume = 1;
+
+    [SerializeField] Slider _slider;
 
     void Awake()
     {
@@ -21,6 +24,12 @@ public class SFXManager : Singleton<SFXManager>
     {
         _volume = num;
         _audioSource.volume = _volume;
+    }
+
+    public void SetVolumeToSlider()
+    {
+        if (_slider == null) { return; }
+        SetVolume(_slider.value);
     }
 
     public void Mute()

--- a/Assets/Scripts/Manager/SceneManager/SceneLoader.cs
+++ b/Assets/Scripts/Manager/SceneManager/SceneLoader.cs
@@ -8,12 +8,17 @@ public class SceneLoader : MonoBehaviour
 
     public void LoadScene()
     {
+        DestroyAllGameObjects();
+        SceneManager.LoadScene(_sceneToLoad);
+    }
+
+    private void DestroyAllGameObjects()
+    {
         GameObject[] objects = FindObjectsOfType<GameObject>();
         // Loop through all game objects and delete them
         foreach (GameObject obj in objects)
         {
             Destroy(obj);
         }
-        SceneManager.LoadScene(_sceneToLoad);
     }
 }

--- a/Assets/Scripts/UI/TransitionBlackout.cs
+++ b/Assets/Scripts/UI/TransitionBlackout.cs
@@ -80,4 +80,8 @@ public class TransitionBlackout : MonoBehaviour
             yield return null;
         }
     }
+
+    void OnDestroy() {
+        Destroy(Player.Instance.gameObject);
+    }
 }

--- a/Assets/Scripts/Upgrade/SpecialUpgrade/TennisShooter.cs
+++ b/Assets/Scripts/Upgrade/SpecialUpgrade/TennisShooter.cs
@@ -73,7 +73,9 @@ public class TennisShooter : MonoBehaviour
             {
                 var target = nonNullList[0].gameObject.transform;
                 var direction= new Vector2(target.position.x - transform.position.x, target.position.y - transform.position.y).normalized;
-                Projectile.InstantiateProjectile(projectileData, this.transform.position + (Vector3) direction * 1.4f, ProjectileOwnerType.player, direction, target.gameObject.GetComponent<Entity>());
+                GameObject projGO = Projectile.InstantiateProjectile(projectileData, this.transform.position + (Vector3) direction * 1.4f, ProjectileOwnerType.player, direction, target.gameObject.GetComponent<Entity>());
+                Projectile proj = projGO.GetComponent<Projectile>();
+                proj.SetEnemyProjectileHighlightGOActive(false);
                 Debug.Log("Shot");
             }
         }


### PR DESCRIPTION
- Change racket hitbox to be slightly larger (1.3 -> 1.7 radius) to make end of racket motion animation look like it hits balls
- Change idle racket sprite to be aligned with mouse direction (rotated 22.5 degrees about Z)
- Change game over menu to not play racket sounds on click (by deleting player when exiting MainScene)
- Change player-fired TennisLauncher upgrade balls to not have red highlight
- Started fixing settings menu to affect sound settings